### PR TITLE
fix(alerter): fix details display for sws batch result

### DIFF
--- a/src/alerter/alerter-directive.js
+++ b/src/alerter/alerter-directive.js
@@ -32,6 +32,10 @@ angular.module('ua.alerter').directive('ovhAlert', function () {
                 $scope.ovhAlertMessageDetails = null;
             };
 
+            $scope.expandDetails = function() {
+                $scope.expand = !$scope.expand;
+            };
+
             if ($attr.ovhAlertHideRemoveButton !== undefined) {
                 $scope.ovhAlertHideRemoveButton = true;
             }

--- a/src/alerter/alerter.html
+++ b/src/alerter/alerter.html
@@ -13,8 +13,10 @@
            data-ng-click="expandDetails()">
         </button>
         <ul data-ng-if="expand">
-            <li class="fs12" data-ng-repeat="ovhAlertMessage in ::ovhAlertMessageDetails track by $index">
-                {{ovhAlertMessage.id}} : {{ovhAlertMessage.message}}
+            <li data-ng-repeat="ovhAlertMessage in ::ovhAlertMessageDetails track by $index">
+                <span data-ng-bind="ovhAlertMessage.id"></span>
+                :
+                <span data-ng-bind="ovhAlertMessage.message"></span>
             </li>
         </ul>
     </div>

--- a/src/alerter/alerter.html
+++ b/src/alerter/alerter.html
@@ -6,12 +6,16 @@
             data-ng-if="!ovhAlertHideRemoveButton"></button>
     <span data-ng-bind-html="ovhAlertMessage"></span>
     <div data-ng-if="ovhAlertMessageDetails">
-        <a class="text-underline"
-           data-tooltip-box
-           data-tb-unique="true"
-           data-tb-content-template="components/ovh-utils-angular/alerter/tooltipErrorMessages.html"
-           data-tb-hide-on-blur="true"
-           data-tb-placement="bottom"
-           data-translate="common_alerts_message_see_more"></a>
+        <button class="btn btn-link"
+           type="button"
+           aria-expanded="{{ expand }}"
+           data-translate="{{ expand ? 'common_alerts_message_see_less' : 'common_alerts_message_see_more' }}"
+           data-ng-click="expandDetails()">
+        </button>
+        <ul data-ng-if="expand">
+            <li class="fs12" data-ng-repeat="ovhAlertMessage in ::ovhAlertMessageDetails track by $index">
+                {{ovhAlertMessage.id}} : {{ovhAlertMessage.message}}
+            </li>
+        </ul>
     </div>
 </div>

--- a/src/alerter/tooltipErrorMessages.html
+++ b/src/alerter/tooltipErrorMessages.html
@@ -1,5 +1,0 @@
-<ul style="margin: 0 0 5px 10px;">
-    <li class="fs12" data-ng-repeat="ovhAlertMessage in ovhAlertMessageDetails">
-        {{ovhAlertMessage.id}} : {{ovhAlertMessage.message}}
-    </li>
-</ul>


### PR DESCRIPTION
## fix details display for sws batch result

Switch tooltip to expanded list because of ng-repeat problems and accessibility 

### Related to : 
https://github.com/ovh-ux/ovh-manager-web/pull/845

Example can be found : MANAGER-2039